### PR TITLE
Fix running cvengine with random UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
 FROM centos:7
 MAINTAINER "Alex Corvin" <acorvin@redhat.com>
 
-RUN yum -y install git python2-setuptools python-pip \
+RUN yum -y install epel-release && yum clean all
+
+RUN yum -y install git python2-setuptools \
     sshpass libffi-devel gcc python-devel \
-    openssl-devel make && yum clean all
+    openssl-devel make nss_wrapper && yum clean all
 
 RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python /tmp/get-pip.py && /bin/rm /tmp/get-pip.py
 RUN pip install --upgrade pip && pip install --upgrade setuptools
 
-COPY . $WORKDIR/cvengine
-RUN cd $WORKDIR/cvengine && python setup.py install
+COPY . /cvengine
+RUN cd /cvengine && python setup.py install
 
-CMD ["cvengine"]
+# Ensure that the root group has write access in $HOME
+# This is necessary because, when running a container in
+# Openshift, a random UID will be assigned at runtime. This
+# UID will not have a valid username, but will be a member
+# of the root group
+RUN chgrp -Rf root $HOME && chmod -Rf g+w $HOME
+
+CMD ["/cvengine/run_container_validation"]

--- a/run_container_validation
+++ b/run_container_validation
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+# Set current user in nss_wrapper
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+
+    NSS_WRAPPER_PASSWD=/tmp/passwd
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cat /etc/passwd | sed -e 's/^default:/builder:/' > $NSS_WRAPPER_PASSWD
+
+    echo "default:x:${USER_ID}:${GROUP_ID}:Default Application User:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=libnss_wrapper.so
+    export LD_PRELOAD
+fi
+
+cvengine


### PR DESCRIPTION
When running the container in Openshift, a random UID is assigned to the
running container. This causes several issues, most notably an inability
to write to $HOME (required by Ansible), and an inability to SSH to a
remote host, which is critical to Ansible running properly (the ssh
command requires a username be associated with the current UID).

This fix is in line with the best practices that I could find for
resolving the issue. Much of the code was copied out of the sclorg
python s2i image. Specifically, the problem is solved by:

1) Changing group ownership of $HOME to root and then making everything
   under $HOME group writeable. This works because, when Openshift
   assigns a random user, that user is in the root group.
2) Enabling the nss_wrapper package. This package wraps the system
   /etc/passwd file, allowing for overriding its contents. The package
   is first installed (after installing epel, where it's installed
   from). In order for nss_wrapper to take effct, a new passwd file
   needs to be created at container runtime. To facilitate this, I
   added a new script that sets up the passwd file and then calls the
   cvengine script. This script is the new default action when running
   the container without overriding cmd