### PR TITLE
Add support for running in ci pipeline

### DIFF
--- a/cvengine/platform_handlers/atomic_host_handler.py
+++ b/cvengine/platform_handlers/atomic_host_handler.py
@@ -27,6 +27,7 @@ class AtomicHostHandler(BasePlatformHandler):
         user = credentials['user']
         key_path = credentials.get('ssh_key_path', None)
         password = credentials.get('password', None)
+        port = credentials.get('port', 22)
         if not key_path and not password:
             msg = 'Either a private key path or password must be given'
             raise ValueError(msg)
@@ -34,7 +35,8 @@ class AtomicHostHandler(BasePlatformHandler):
             'host': self.remote_host,
             'user': user,
             'ssh_key_path': key_path,
-            'password': password
+            'password': password,
+            'port': port
         }
 
         self.extra_vars['current_host_ip'] = self.test_host['ip_address']

--- a/cvengine/platform_handlers/base_platform_handler.py
+++ b/cvengine/platform_handlers/base_platform_handler.py
@@ -200,10 +200,15 @@ class BasePlatformHandler(object):
                     pass  # Not grounds for had fail if nonexistent dir
 
             print('Fetching container artifacts from host')
-            fetch_remote_artifact(self.remote_host,
-                                  self.remote_host_creds,
-                                  self.host_data_out,
-                                  artifacts_directory)
+            try:
+                fetch_remote_artifact(self.remote_host,
+                                      self.remote_host_creds,
+                                      self.host_data_out,
+                                      artifacts_directory,
+                                      target_port=self.remote_host_creds['port'])
+            except:
+                print traceback.format_exc()
+                raise
 
         if self.artifacts and 'test_host_artifacts' in self.artifacts:
             for artifact in self.artifacts['test_host_artifacts']:
@@ -214,8 +219,10 @@ class BasePlatformHandler(object):
                                                      artifacts_directory)
                         run_ansible_cmd(cmd, local=True)
                     else:
+                        port = self.remote_host_creds['port']
                         fetch_remote_artifact(self.remote_host,
                                               self.remote_host_creds, artifact,
-                                              artifacts_directory)
+                                              artifacts_directory,
+                                              target_port=port)
                 except Exception:
                     pass  # Not grounds for had fail if nonexistent dir

--- a/cvengine/util/ansible_handler.py
+++ b/cvengine/util/ansible_handler.py
@@ -2,7 +2,7 @@ import tempfile
 
 
 def write_ansible_inventory(host, user, ssh_key_path=None,
-                            password=None):
+                            password=None, port=None):
     """Write an ansible inventory file
 
     Creates a file on disk to be used as an ansible inventory file for a
@@ -44,6 +44,9 @@ def write_ansible_inventory(host, user, ssh_key_path=None,
     if ssh_key_path:
         key_line = '\n ansible_ssh_private_key_file={0}'
         contents += key_line.format(ssh_key_path)
+
+    if port:
+        contents += '\nansible_ssh_port={0}'.format(port)
 
     with open(inventory_file.name, 'w') as f:
         f.write(contents)

--- a/cvengine/util/fetch.py
+++ b/cvengine/util/fetch.py
@@ -44,7 +44,7 @@ def get_file_type(ssh_connection, file_path):
         return 'File'
 
 
-def setup_ssh_connection(target_machine, target_credentials):
+def setup_ssh_connection(target_machine, target_credentials, port=22):
     """Helper function to instantiate a ssh connection to a remote host
 
     Instantiates a wrapper around an SSH connection to a remote host. A
@@ -66,9 +66,10 @@ def setup_ssh_connection(target_machine, target_credentials):
                                                         None),
                  'look_for_keys': True,
                  'allow_agent': True,
-                 'port': 22}
+                 'port': port}
     ssh = paramiko.SSHClient()
     ssh.load_system_host_keys()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(target_machine, **ssh_creds)
 
     return ssh
@@ -76,6 +77,7 @@ def setup_ssh_connection(target_machine, target_credentials):
 
 def fetch_remote_artifact(target_machine, target_credentials,
                           remote_file_path, artifacts_directory,
+                          target_port=22,
                           connect_from_host={'host': 'localhost'}):
     """Fetch an artifact from a remote machine
 
@@ -107,7 +109,8 @@ def fetch_remote_artifact(target_machine, target_credentials,
     destination_path = os.path.join(artifacts_directory, target_basename)
 
     ssh_connection = setup_ssh_connection(target_machine,
-                                          target_credentials)
+                                          target_credentials,
+                                          port=target_port)
 
     try:
         file_type = get_file_type(ssh_connection, remote_file_path)


### PR DESCRIPTION
This change adds a few items that will be necessary to facilitate
running cvengine in the ci pipeline:

1. Support specifying an arbitrary SSH port in the ansible inventory
   and in the fetching remote artifacts

2. Add proper error handling to fetching remote artifacts

3. Disable ssh key checking for hosts when fetching remote artifacts