### PR TITLE
Add support for running validations against fedora platforms

### DIFF
--- a/cvengine/cvengine.py
+++ b/cvengine/cvengine.py
@@ -91,6 +91,7 @@ def run_container_validation(image_url, chidata_url, config,
     handler = handler_class(scenario, environment_config,
                             artifacts, extra_variables)
     try:
+        handler.setup()
         handler.run()
     except Exception:
         msg = 'Error encountered while running handler: {0}'

--- a/cvengine/cvengine.py
+++ b/cvengine/cvengine.py
@@ -9,11 +9,13 @@ import yaml
 from .cvdata import CVData
 from .util import run
 from .platform_handlers.atomic_host_handler import AtomicHostHandler
+from .platform_handlers.fedora_handler import FedoraHandler
 
 
 host_type_handlers = {
     'dashost': AtomicHostHandler,
-    'atomic': AtomicHostHandler
+    'atomic': AtomicHostHandler,
+    'fedora': FedoraHandler
 }
 
 

--- a/cvengine/platform_handlers/base_platform_handler.py
+++ b/cvengine/platform_handlers/base_platform_handler.py
@@ -124,6 +124,20 @@ class BasePlatformHandler(object):
         with open(self.extra_vars_file.name, 'w') as f:
             json.dump(extra_vars, f)
 
+    def setup(self):
+        """Base setup function for platform handlers
+
+        The setup function will be called before the run function. This
+        is intended to be used when some level of setup/initialization
+        is necessary to prepare the container platform. Not all platforms
+        will make use of this.
+        """
+        if self.run_playbooks_locally:
+            self.ansible_inv = 'localhost, '
+        else:
+            creds_data = self.remote_host_creds
+            self.ansible_inv = write_ansible_inventory(**creds_data)
+
     def run(self):
         """Execute the container validation on the target platform
 
@@ -137,12 +151,6 @@ class BasePlatformHandler(object):
             Exception: A generic exception if any of the playbooks fail
 
         """
-        if self.run_playbooks_locally:
-            self.ansible_inv = 'localhost, '
-        else:
-            creds_data = self.remote_host_creds
-            self.ansible_inv = write_ansible_inventory(**creds_data)
-
         run_ansible_cmd('mkdir {0}'.format(self.extra_vars['host_data_out']),
                         self.ansible_inv,
                         self.ansible_config_file,

--- a/cvengine/platform_handlers/base_platform_handler.py
+++ b/cvengine/platform_handlers/base_platform_handler.py
@@ -209,12 +209,13 @@ class BasePlatformHandler(object):
 
             print('Fetching container artifacts from host')
             try:
+                port = self.remote_host_creds['port']
                 fetch_remote_artifact(self.remote_host,
                                       self.remote_host_creds,
                                       self.host_data_out,
                                       artifacts_directory,
-                                      target_port=self.remote_host_creds['port'])
-            except:
+                                      target_port=port)
+            except Exception:
                 print traceback.format_exc()
                 raise
 

--- a/cvengine/platform_handlers/fedora_handler.py
+++ b/cvengine/platform_handlers/fedora_handler.py
@@ -1,0 +1,37 @@
+from atomic_host_handler import AtomicHostHandler
+from cvengine.util.run import run_ansible_cmd
+
+
+class FedoraHandler(AtomicHostHandler):
+    """Platform handler for Fedora hosts
+
+    This class is used to execute container validations against traditional
+    Fedora hosts and similar. Specifically, this is used for a host that
+    needs to be bootstrapped with docker installed and running. Once
+    that condition is met, the container validation is the same as for an
+    Atomic Host, so this class subclassed the AtomicHostHandler.
+    """
+
+    def setup(self):
+        """Setup function for Fedora hosts
+
+        This function performs the necessary steps to bootstrap the remote
+        Fedora host to run containers. Specifically, we install python2
+        (necessary to be able to run more ansible commands against the host,
+        then install, enable, and start Docker.
+        """
+        super(AtomicHostHandler, self).setup()
+
+        # Bootstrap the node to ensure python2 is installed
+        run_ansible_cmd('dnf -y install python2',
+                        self.ansible_inv,
+                        self.ansible_config_file,
+                        module='raw')
+
+        commands = ['dnf -y install docker',
+                    'systemctl enable docker',
+                    'systemctl start docker']
+        for command in commands:
+            run_ansible_cmd(command,
+                            self.ansible_inv,
+                            self.ansible_config_file)

--- a/cvengine/util/run.py
+++ b/cvengine/util/run.py
@@ -45,7 +45,7 @@ def run_cmd(cmd, virtualenv=None, working_directory=None, env_vars={}):
 
 
 def run_ansible_cmd(cmd, inventory, ansible_config,
-                    local=False, sudo=True):
+                    module='command', local=False, sudo=True):
     """Helper function to run an ansible command
 
     Execute the specified command in a local shell via ansible. This is used
@@ -60,6 +60,9 @@ def run_ansible_cmd(cmd, inventory, ansible_config,
             be a path to an ansible inventory file. Additionally, it could be
             the string "localhost", or an IP address
         ansible_config (str): A path to an ansible config file
+        module (str, optional): The ansible module to use. This is passed to
+            the ansible command as the value of the '-m' argument. Defaults
+            to 'command'.
         local (bool, optional): Whether the command should be executed against
             the local machine. If false, we assume that the target of the
             ansible command is a remote host. Defaults to False.
@@ -70,14 +73,15 @@ def run_ansible_cmd(cmd, inventory, ansible_config,
     if local:
         ans = ('ANSIBLE_CONFIG={cfg} '
                'ansible all '
-               '-v -i "{inventory}" -c local -m cmd -a "{cmd}"')
+               '-v -i "{inventory}" -c local -m {mod} -a "{cmd}"')
         ans = ans.format(cfg=ansible_config, inventory=inventory,
-                         cmd=cmd)
+                         cmd=cmd, mod=module)
     else:
         ans = ('ANSIBLE_CONFIG={cfg} '
                'ansible all '
-               '-v -i "{inventory}" -a "{cmd}" {become}')
+               '-v -i "{inventory}" {become} -m {mod} -a "{cmd}"')
         ans = ans.format(cfg=ansible_config, cmd=cmd,
+                         mod=module,
                          inventory=inventory,
                          become=('--become' if sudo else ''))
 

--- a/example/cvdata.yml
+++ b/example/cvdata.yml
@@ -3,6 +3,10 @@ Test:
     instance_name: cvengine_example
     playbooks:
       - url: https://github.com/CentOS-PaaS-SIG/cvengine/raw/master/example/atomic-playbook.yml
+  - host_type: fedora
+    instance_name: cvengine_example
+    playbooks:
+      - url: https://github.com/CentOS-PaaS-SIG/cvengine/raw/master/example/atomic-playbook.yml
 
 Artifacts:
   container_artifacts:


### PR DESCRIPTION
This enables running container validations against fedora and fedora like platforms. Specifically, this is enabled by first installing and starting Docker on the target host. After that, the validation is executed identically to Atomic Host validations.