### PR TITLE
Add environment handlers

### DIFF
--- a/cvengine/cvdata.py
+++ b/cvengine/cvdata.py
@@ -68,7 +68,8 @@ class CVData():
         scenario = None
         for platform in metadata['Test']:
             if ((platform['host_type'] == target_platform) or
-                    (platform['default'] and target_platform is None)):
+                    (platform.get('default', False) and target_platform
+                     is None)):
                 scenario = platform
                 break
 

--- a/cvengine/cvengine.py
+++ b/cvengine/cvengine.py
@@ -8,6 +8,7 @@ import yaml
 
 from .cvdata import CVData
 from .util import run
+from .environment_handlers.openstack_environment import OpenstackEnvironment
 from .environment_handlers.preconfigured_environment import \
         PreConfiguredEnvironment
 from .platform_handlers.atomic_host_handler import AtomicHostHandler
@@ -15,7 +16,8 @@ from .platform_handlers.fedora_handler import FedoraHandler
 
 
 environment_handlers = {
-    'preconfigured': PreConfiguredEnvironment
+    'preconfigured': PreConfiguredEnvironment,
+    'openstack': OpenstackEnvironment
 }
 
 platform_handlers = {

--- a/cvengine/cvengine.py
+++ b/cvengine/cvengine.py
@@ -8,11 +8,17 @@ import yaml
 
 from .cvdata import CVData
 from .util import run
+from .environment_handlers.preconfigured_environment import \
+        PreConfiguredEnvironment
 from .platform_handlers.atomic_host_handler import AtomicHostHandler
 from .platform_handlers.fedora_handler import FedoraHandler
 
 
-host_type_handlers = {
+environment_handlers = {
+    'preconfigured': PreConfiguredEnvironment
+}
+
+platform_handlers = {
     'dashost': AtomicHostHandler,
     'atomic': AtomicHostHandler,
     'fedora': FedoraHandler
@@ -62,13 +68,13 @@ def run_container_validation(image_url, chidata_url, config,
         msg = ('The specified target host platform did not match any '
                'options configured in the metadata file. Supported '
                'host_type values are: {0}')
-        raise ValueError(msg.format(host_type_handlers.keys()))
+        raise ValueError(msg.format(platform_handlers.keys()))
 
-    if scenario['host_type'] not in host_type_handlers:
+    if scenario['host_type'] not in platform_handlers:
         msg = ('{0} is not a valid host_type. Support host_type values'
                'are: {1}')
         raise ValueError(msg.format(scenario['host_type'],
-                                    host_type_handlers.keys()))
+                                    platform_handlers.keys()))
 
     # pre-download playbook files
     playbooks = scenario['playbooks']
@@ -89,18 +95,24 @@ def run_container_validation(image_url, chidata_url, config,
 
     extra_variables['image_url'] = image_url
 
-    handler_class = host_type_handlers[scenario['host_type']]
-    handler = handler_class(scenario, environment_config,
-                            artifacts, extra_variables)
+    environment = environment_config.get('handler', 'preconfigured')
+    environment_class = environment_handlers[environment]
+    environment = environment_class(environment_config)
+    environment.prepare()
+
+    platform_class = platform_handlers[scenario['host_type']]
+    platform = platform_class(scenario, environment,
+                              artifacts, extra_variables)
     try:
-        handler.setup()
-        handler.run()
+        platform.setup()
+        platform.run()
     except Exception:
         msg = 'Error encountered while running handler: {0}'
         print(msg.format(traceback.format_exc()))
         raise
     finally:
-        handler.teardown(artifacts_directory)
+        platform.teardown(artifacts_directory)
+        environment.teardown()
 
 
 def main():

--- a/cvengine/environment_handlers/base_environment_handler.py
+++ b/cvengine/environment_handlers/base_environment_handler.py
@@ -1,0 +1,73 @@
+class BaseEnvironmentHandler(object):
+    """Base class for interacting with environments
+
+    Environments in cvengine encapsulate the host(s) that a container platform
+    gets deployed on. These could be a single host that is connected to via
+    SSH, a cloud platform that hosts get provisioned on, etc. This base class
+    provides the common interfact definition for specific environment
+    implementations.
+
+    Attributes:
+        host_name (str): The name of the container platform host
+        host_ip (str): The IP address to the container platform host
+        username (str): The username for connecting to the container platform
+            host
+        password (str): The password for connecting to the container platform
+            host
+        ssh_key_path (str): A path to the private key to be used for connecting
+            to the container platform host
+        port (int): The port number to be used to ssh to the container platform
+            host
+    """
+    def __init__(self):
+        pass
+
+    def prepare(self):
+        """Function to set up the environment before the run
+
+        Any steps required to create the environment or container platform
+        hosts should be performed in the prepare function. This will be
+        executed prior to instantiating and running the platform handler.
+
+        """
+        pass
+
+    def set_required_data(self, name, ip, username, password, ssh_key_path,
+                          port):
+        """Function for setting the required class attributes
+
+        This function sets up the required class attributes that will be used
+        by the platform handlers to connect to the container platform host.
+        Using this function to set the attributes rather than having them
+        set individually in the implementing classes makes it easier to see
+        what class attributes are required.
+
+        Args:
+            name (str): The name of the container platform host
+            ip (str): The IP address to the container platform host
+            username (str): The username for connecting to the container
+                platform host
+            password (str): The password for connecting to the container
+                platform host
+            ssh_key_path (str): A path to the private key to be used for
+                connecting to the container platform host
+            port (int): The port number to be used to ssh to the container
+                platform host
+        """
+        self.host_name = name
+        self.host_ip = ip
+        self.username = username
+        self.password = password
+        self.ssh_key_path = ssh_key_path
+        self.port = port
+
+    def teardown(self):
+        """Function to tear down the environment after the run
+
+        Any environment teardown steps (deleting VMs, etc.) should be
+        performed in the teardown function. This will be called after
+        the container validation completes and after the platform teardown
+        is called. This function will be called regardless of whether the
+        container validation executes successfully.
+        """
+        pass

--- a/cvengine/environment_handlers/openstack_environment.py
+++ b/cvengine/environment_handlers/openstack_environment.py
@@ -1,0 +1,273 @@
+import base64
+import random
+import string
+import uuid
+
+from keystoneclient.v2_0 import client as ksclient
+from neutronclient.neutron import client
+from openstack import connection
+from .base_environment_handler import BaseEnvironmentHandler
+from cvengine.util import run
+
+
+RAW_USER_DATA = ('#cloud-config\n'
+                 'ssh_pwauth: True\n'
+                 'disable_root: False\n'
+                 'chpasswd:\n'
+                 '  list: |\n'
+                 '    {user}:{password}\n'
+                 '  expire: False')
+
+
+class OpenstackEnvironment(BaseEnvironmentHandler):
+    """Environment handler for provisioning container platforms on OpenStack
+
+    The OpenStack environment handler is used to provision a target
+    container platform as a VM within an OpenStack cloud. This is used
+    to create a VM from a target image then assign a floating IP to that
+    VM. The IP, credentials, etc. for this VM are then used by the platform
+    handler to interact with the container platform.
+    """
+    def __init__(self, env_config):
+        """Function to initialize the environment handler
+
+        This parses the required configuration data and generates any class
+        attributes that will be used later on when preparing the environment.
+
+        Args:
+            env_config (dict): The environment configuration dictionary from
+                the container validation config
+        """
+        assert 'openstack' in env_config
+        assert 'host' in env_config
+        self.osp_conf = env_config['openstack']
+        self.host_conf = env_config['host']
+        self.server_name = 'cvhost-{id}'.format(id=uuid.uuid4())
+        self.username = 'root'
+        self.password = self.generate_password()
+        self.userdata = self.generate_user_data(self.username, self.password)
+
+    def prepare(self):
+        """Function to create the container platform host
+
+        This function connects to OpenStack, creates the server, assigns a
+        floating IP to it, and then waits until it can be reached via SSH.
+
+        """
+        self.osp_conn, self.neutron, self.tenant = \
+            self.setup_osp_conn(self.osp_conf)
+        self.host = self.create_host(self.osp_conn, self.host_conf,
+                                     self.server_name, self.userdata)
+        self.server_id = self.host.id
+        self.fip = self.assign_ip(self.neutron, self.host_conf, self.host,
+                                  self.tenant)
+        ip = self.fip['floatingip']['floating_ip_address']
+        self.set_required_data(self.server_name, ip, self.username,
+                               self.password, None, 22)
+        run.wait_for_ssh(ip, self.username, self.password)
+
+    def teardown(self):
+        """Tear down the floating IP and server
+
+        Delete the floating IP that was attached to the server then delete
+        the server
+        """
+        fip_id = self.fip['floatingip']['id']
+        self.neutron.delete_floatingip(fip_id)
+        self.osp_conn.compute.delete_server(self.server_id)
+
+    def setup_osp_conn(self, osp_conf):
+        """Function to instantiate the connection to OpenStack
+
+        This function parses the OpenStack connection information from the
+        environment confi, verifying that required keys are set. It then
+        instantiates connections to openstack and neutron.
+
+        Args:
+            osp_conf (dict): The openstack configuration dictionary from
+                the environment config
+
+        Returns:
+            openstack.Connection: The OpenStack connection object
+            neutronclient.Client: The connection to OpenStack Neutron
+            str: The keystone connection token
+        """
+        required_keys = ['auth_url', 'project', 'username', 'password',
+                         'region']
+        for key in required_keys:
+            assert key in osp_conf
+
+        auth_url = osp_conf['auth_url']
+        project_name = osp_conf['project']
+        username = osp_conf['username']
+        password = osp_conf['password']
+        region = osp_conf['region']
+        conn = connection.Connection(auth_url=auth_url,
+                                     project_name=project_name,
+                                     username=username,
+                                     password=password)
+        kclient = ksclient.Client(username=username,
+                                  password=password,
+                                  tenant_name=project_name,
+                                  auth_url=auth_url,
+                                  region_name=region)
+        token = kclient.auth_token
+        endpoint = kclient.service_catalog.url_for(service_type='network',
+                                                   endpoint_type='publicURL')
+        neutron = client.Client('2.0', token=token, endpoint_url=endpoint)
+        return conn, neutron, token
+
+    def generate_password(self):
+        """Function to generate a random password
+
+        Returns:
+            str: The password string
+        """
+        characters = string.ascii_letters + string.punctuation + string.digits
+        password = ''.join(random.choice(characters) for x in
+                           range(random.randint(8, 18)))
+        return password
+
+    def generate_user_data(self, user, password):
+        """Function to generate the cloud-init user data string
+
+        This generates the cloud-init user data wich is used to specify the
+        root user password and allow password SSH as root.
+
+        Returns:
+            str: The base 64 encoded userdata string
+        """
+        raw_user_data = RAW_USER_DATA.format(user=user, password=password)
+        user_data = base64.b64encode(raw_user_data)
+        return user_data
+
+    def create_host(self, osp_conn, host_conf, server_name, userdata):
+        """Create the OpenStack server instance
+
+        This creates the OpenStack instance using the target image, flavor,
+        network, and keypair then waits until it has been created.
+
+        Args:
+            osp_conn (openstack.Connection): The connection to OpenStack
+            host_conf (dict): The environment config dictionary with keys
+                for how the host should be created.
+            server_name (str): The name that should be assigned to the server
+            userdata (str): The base 64 encoded user data string that will be
+                passed to the cloud init system when instantiating the server
+
+        Returns:
+            openstack.Server: The openstack server object
+        """
+
+        host_keys = ['image_name', 'flavor_name', 'network_name',
+                     'keypair_name']
+        for key in host_keys:
+            assert key in host_conf
+
+        image = osp_conn.compute.find_image(host_conf['image_name'])
+        flavor = osp_conn.compute.find_flavor(host_conf['flavor_name'])
+        network = osp_conn.network.find_network(host_conf['network_name'])
+        keypair = osp_conn.compute.find_keypair(host_conf['keypair_name'])
+
+        host = osp_conn.compute.create_server(name=server_name,
+                                              image_id=image.id,
+                                              flavor_id=flavor.id,
+                                              networks=[{"uuid": network.id}],
+                                              key_name=keypair.name,
+                                              user_data=userdata)
+        host = osp_conn.compute.wait_for_server(host)
+        return host
+
+    def assign_ip(self, neutron, host_conf, host, tenant):
+        """Assign a floating IP to the server
+
+        This creates a (or obtains an existing but unassigned) floating IP
+        then assigns it to the target host.
+
+        Args:
+            neutron (neutronclient.Client): The neutron connection object
+            host_conf (dict): The environment config dictionary with keys
+                for how the host should be created
+            host (openstack.Server): The OpenStack server object that the
+                floating IP will be attached to
+            tenant (str): The OpenStack tenant ID. Used to find available
+                floating IPs that are not yet assigned
+
+        Returns:
+            dict: The floating IP data
+        """
+        assert 'floating_ip_pool_name' in host_conf
+        pool_name = host_conf['floating_ip_pool_name']
+        pool_id = self.get_floating_pool_id(neutron, pool_name)
+        server_port = self.get_server_port(neutron, host)
+        return self.get_or_create_ip(neutron, pool_id, server_port, tenant)
+
+    def get_floating_pool_id(self, neutron, pool_name):
+        """Get the network ID of the target floating IP pool
+
+        To create a floating IP in a pool we need to know the ID of the
+        target pool. This gets that ID using the name of the target pool.
+
+        Args:
+            neutron (neutronclient.Client): The neutron connection object
+            pool_name (str): The name of the target floating IP pool
+
+        Returns:
+            str: The network ID of the floating IP pool
+        """
+        networks = neutron.list_networks(name=pool_name)
+        if not networks['networks']:
+            raise Exception()
+        return networks['networks'][0]['id']
+
+    def get_server_port(self, neutron, server):
+        """Get the ID of the server's network port
+
+        To attach a floating IP to a server we need to know the ID of the
+        network port on the server that the IP should be attached to. This
+        gets that ID using the ID of the target server.
+
+        Args:
+            neutron (neutronclient.Client): The neutron connection object
+            server (openstack.Server): The OpenStack server object that the
+                floating IP will be attached to
+
+        Returns:
+            str: The ID of the server network port
+        """
+        ports = neutron.list_ports(device_id=server.id)
+        if not ports['ports']:
+            raise Exception()
+        return ports['ports'][0]['id']
+
+    def get_or_create_ip(self, neutron, floating_net, server_port, tenant):
+        """Create a floating IP in the target pool or get an existing one
+
+        This function first checks if any unassigned floating IPs exist in the
+        target pool. If there is one, the first available one is returned. If
+        none exist, a new floating IP is created in the target pool and
+        returned.
+
+        Args:
+            neutron (neutronclient.Client): The neutron connection object
+            floating_net (str): The network ID of the floating IP pool to get
+                a floating IP from
+            server_port (str): The ID of the server network port that the
+                floating IP should be attached to
+            tenant (str): The OpenStack tenant ID
+
+        Returns:
+            dict: The floating IP response data
+        """
+
+        ips = neutron.list_floatingips(floating_network_id=floating_net)
+        fip = next((fip for fip in ips['floatingips'] if fip['port_id'] is
+                    None and fip['tenant_id'] == tenant), None)
+        if fip is None:
+            fip_data = {'floatingip': {'port_id': server_port,
+                                       'floating_network_id': floating_net}}
+            fip = neutron.create_floatingip(fip_data)
+        else:
+            fip_data = {'floatingip': {'port_id': server_port}}
+            fip = neutron.update_floatingip(fip['id'], fip_data)
+        return fip

--- a/cvengine/environment_handlers/preconfigured_environment.py
+++ b/cvengine/environment_handlers/preconfigured_environment.py
@@ -1,0 +1,45 @@
+from .base_environment_handler import BaseEnvironmentHandler
+
+
+class PreConfiguredEnvironment(BaseEnvironmentHandler):
+    """Environment handler for hosts that have already been provisioned
+
+    PreConfigured environments are those where the container platform already
+    exists when cvengine is called. Some process (either a human manually or
+    the process which calls cvengine) has already set up the container
+    platform and passed in the IP address, credentials, etc for the
+    environment in the environment section of the config.
+
+    Todo:
+        * This environment handler expects the config information about the
+          environment host to be under a sub-key named "atomic-host" within
+          the environment config section. This should be more modified to
+          be more generic. Doing so will require updating implementations
+          of cvengine to change the key they use to publish
+    """
+    def __init__(self, env_config):
+        """Function to initialize the environment handler
+
+        This parses the required configuration data and sets the necessary
+        class attributes.
+
+        Args:
+            env_config (dict): The environment configuration dictionary from
+                the container validation config
+        """
+        assert 'atomic-host' in env_config
+        host = env_config['atomic-host'][0]
+
+        keys = ['machine_name', 'ip_address', 'credentials']
+        for key in keys:
+            assert key in host
+
+        server_name = host['machine_name']
+        ip = host['ip_address']
+        credentials = host['credentials']
+        username = credentials['user']
+        password = credentials.get('password', None)
+        ssh_key = credentials.get('ssh_key_path', None)
+        port = credentials.get('port', 22)
+        self.set_required_data(server_name, ip, username,
+                               password, ssh_key, port)

--- a/cvengine/platform_handlers/atomic_host_handler.py
+++ b/cvengine/platform_handlers/atomic_host_handler.py
@@ -12,22 +12,20 @@ class AtomicHostHandler(BasePlatformHandler):
     on the Atomic host.
 
     """
-    def __init__(self, host_test, env_config_yaml,
+    def __init__(self, host_test, environment,
                  artifacts, common_vars):
 
-        super(AtomicHostHandler, self).__init__(host_test, env_config_yaml,
+        super(AtomicHostHandler, self).__init__(host_test, environment,
                                                 artifacts, common_vars)
 
         self.extra_vars['exec_cmd'] = 'docker {0}'.format(self.EXEC_CMD_SUFFIX)
         self.fetch_artifact_cmd = 'docker cp'
 
-        self.test_host = self.env_config['atomic-host'][0]
-        self.remote_host = self.test_host['ip_address']
-        credentials = self.test_host['credentials']
-        user = credentials['user']
-        key_path = credentials.get('ssh_key_path', None)
-        password = credentials.get('password', None)
-        port = credentials.get('port', 22)
+        self.remote_host = environment.host_ip
+        user = environment.username
+        key_path = environment.ssh_key_path
+        password = environment.password
+        port = environment.port
         if not key_path and not password:
             msg = 'Either a private key path or password must be given'
             raise ValueError(msg)
@@ -39,8 +37,8 @@ class AtomicHostHandler(BasePlatformHandler):
             'port': port
         }
 
-        self.extra_vars['current_host_ip'] = self.test_host['ip_address']
-        self.extra_vars['host_machine_name'] = self.test_host['machine_name']
+        self.extra_vars['current_host_ip'] = self.remote_host
+        self.extra_vars['host_machine_name'] = environment.host_name
         self.run_playbooks_locally = False
         self.ansible_cmd = ('ANSIBLE_CONFIG={cfg} '
                             'ansible-playbook '

--- a/cvengine/platform_handlers/base_platform_handler.py
+++ b/cvengine/platform_handlers/base_platform_handler.py
@@ -27,19 +27,17 @@ class BasePlatformHandler(object):
 
     EXEC_CMD_SUFFIX = 'exec -i {0}'
 
-    def __init__(self, host_test, env_config_yaml,
+    def __init__(self, host_test, environment,
                  artifacts, common_vars):
         """
         Args:
             host_test (dict): Dictionary containing information about the
                 currently running scenario. Includes the playbooks to be
                 executed, instance name, and playbook variables
-            env_config_yaml (dict): Dictionary containing information about
-                the target environment. Environments are the representation
-                in cvengine of the hosts/systems on which a platform gets
-                deployed (or already is deployed). Specific subkeys depend on
-                the specific environment type that the validation is being run
-                against.
+            environment (:obj: `BaseEnvironmentHandler`): An object
+                representing the hosts/systems on which a platform gets
+                deployed (or already is deployed). This will be a specific
+                sub-class implementation of the BaseEnvironmentHandler.
             artifacts (dict): Dictionary containing sets of artifacts to be
                 retrieved after running the validation.
             common_vars (dict): Dictionary containing a set of variables to be
@@ -55,7 +53,6 @@ class BasePlatformHandler(object):
               handler.
         """
         self.host_test = host_test
-        self.env_config = env_config_yaml
         self.playbooks = self.host_test['playbooks']
         self.instance_name = self.host_test.get('instance_name',
                                                 'container_instance')

--- a/cvengine/platform_handlers/existing_openshift_handler.py
+++ b/cvengine/platform_handlers/existing_openshift_handler.py
@@ -21,11 +21,11 @@ class ExistingOpenshiftHandler(BasePlatformHandler):
           official support for this.
 
     """
-    def __init__(self, host_test, env_config_yaml,
+    def __init__(self, host_test, environment,
                  artifacts, common_vars):
 
         super(ExistingOpenshiftHandler, self).__init__(host_test,
-                                                       env_config_yaml,
+                                                       environment,
                                                        artifacts, common_vars)
 
         oc_path = get_install_oc()

--- a/cvengine/util/run.py
+++ b/cvengine/util/run.py
@@ -1,3 +1,7 @@
+import time
+import traceback
+
+from .fetch import setup_ssh_connection
 from subprocess import Popen, PIPE
 
 
@@ -86,3 +90,20 @@ def run_ansible_cmd(cmd, inventory, ansible_config,
                          become=('--become' if sudo else ''))
 
     return run_cmd(ans)
+
+
+def wait_for_ssh(host, username, password, wait_time=30, sleep_interval=5):
+    creds = {'user': username, 'password': password}
+    start_time = time.time()
+    end_time = start_time + wait_time
+    connected = False
+    while time.time() < end_time:
+        try:
+            setup_ssh_connection(host, creds)
+            connected = True
+            break
+        except Exception:
+            time.sleep(sleep_interval)
+    if not connected:
+        msg = 'The remote host failed to become available via ssh: {0}'
+        raise Exception(msg.format(traceback.format_exc()))

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,6 @@ setup(name='cvengine',
                         'scp',
                         'diaper',
                         'pyyaml',
-                        'ansible'])
+                        'ansible',
+                        'python-openstackclient',
+                        'python-neutronclient'])


### PR DESCRIPTION
Environment handlers encapsulate (and sometime set up) the hosts that the container platforms run on. In the default case, the environment is already set up, so cvengine just gets passed the IP address and credentials to the environment host. This change adds the base environment handler and PreConfiguredEnvironment to handle that default case. This change also adds the OpenStackEnvironment which is used to provision a host as an OpenStack VM that then serves as the container platform.