### PR TITLE
Clean up error output for unimplemented platform

### DIFF
--- a/cvengine/cvdata.py
+++ b/cvengine/cvdata.py
@@ -65,12 +65,23 @@ class CVData():
             dict: The metadata information for the target scenario
         """
         target_platform = config.get('target_host_platform', None)
+        implemented_platforms = []
         scenario = None
         for platform in metadata['Test']:
-            if ((platform['host_type'] == target_platform) or
+            platform_name = platform['host_type']
+            implemented_platforms.append(platform_name)
+            if ((platform_name == target_platform) or
                     (platform.get('default', False) and target_platform
                      is None)):
                 scenario = platform
                 break
+
+        if not scenario:
+            msg = ('The specified target host platform ({target}) did not '
+                   'match any options configured in the metadata file. '
+                   'Definitions were found for the following container '
+                   'platforms: {platforms}')
+            raise ValueError(msg.format(target=target_platform,
+                                        platforms=implemented_platforms))
 
         return scenario

--- a/cvengine/cvengine.py
+++ b/cvengine/cvengine.py
@@ -66,12 +66,6 @@ def run_container_validation(image_url, chidata_url, config,
     artifacts = cvdata.artifacts
     environment_config = cvdata.environment
 
-    if not scenario:
-        msg = ('The specified target host platform did not match any '
-               'options configured in the metadata file. Supported '
-               'host_type values are: {0}')
-        raise ValueError(msg.format(platform_handlers.keys()))
-
     if scenario['host_type'] not in platform_handlers:
         msg = ('{0} is not a valid host_type. Support host_type values'
                'are: {1}')


### PR DESCRIPTION
If a definition for the target container platform does not exist in the
metadata file then the validation can't continue. The previous error
message for this condition was unclear, so this change modifies that
message to make the exact error condition easier to understand.